### PR TITLE
Remove useless author parameter

### DIFF
--- a/frontend/src/components/ArticleForm.js
+++ b/frontend/src/components/ArticleForm.js
@@ -11,8 +11,8 @@ const ArticleForm = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    const article = { title, summary, body, author: "alex" };
-    const response = await fetch(`/api/articles/create`, {
+    const article = { title, summary, body };
+    const response = await fetch("/api/articles/create", {
       method: "POST",
       body: JSON.stringify(article),
       headers: {


### PR DESCRIPTION
Remove author parameter in frontend when creating article This parameter is set by the backend during the auth check
This PR needs a test before merging, and I'll wait for the end of #20 to do so. 