### PR TITLE
Introduce `bump.sh` script to automate version bumping

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ iscsc.fr
 │       ├── index.js            *main js application of the website*
 │       └── index.css           *css styling file of the website*
 │
+├── bump.sh             *script used to bump version of frontend, backend and whole website*
+├── package.json        *contains the current version and informations about the website*
 └── README.md           *this file*
 ```
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ iscsc.fr
 ├── .env.production     *Same thing for production mode. Must be created*
 ├── .env.example        *template for .env files*
 │
-├── backend                 *contains the server-side code and API*
+├── backend             *contains the server-side code and API*
 │   ├── controllers/        *usefull js functions for each model*
 │   ├── middleware/         *js functions that run between the frontend and backend*
 │   ├── models/             *contains the database models*
@@ -153,15 +153,15 @@ iscsc.fr
 ├── frontend
 │   ├── public              *automatically generated files and images that are publically available for the user*
 │   └── src                 *source code of the website*
-│       ├── components/     *source code of main components of the website*
-│       ├── context/        *defines the context function to keep track data with useReducer*
-│       ├── hooks/          *defines the hooks that trigger the context functions*
-│       ├── pages/          *source code of the pages of the website*
-│       ├── App.js          *defines the routes of the application*
-│       ├── index.js        *main js application of the website*
-│       └── index.css       *css styling file of the website*
+│       ├── components/         *source code of main components of the website*
+│       ├── context/            *defines the context function to keep track data with useReducer*
+│       ├── hooks/              *defines the hooks that trigger the context functions*
+│       ├── pages/              *source code of the pages of the website*
+│       ├── App.js              *defines the routes of the application*
+│       ├── index.js            *main js application of the website*
+│       └── index.css           *css styling file of the website*
 │
-└── README.md               *this file*
+└── README.md           *this file*
 ```
 
 ## Bugs and recommendations

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "dev": "NODE_ENV=development nodemon",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
     "version": "npm install && git add package.json package-lock.json"
   },
   "author": "Alexandre Tullot",

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "NODE_ENV=development nodemon",
     "test": "echo \"Error: no test specified\" && exit 1"
+    "version": "npm install && git add package.json package-lock.json"
   },
   "author": "Alexandre Tullot",
   "license": "ISC",

--- a/bump.sh
+++ b/bump.sh
@@ -31,7 +31,13 @@ fi
 CURRENT=$(npm pkg get version | sed 's/"//g')
 NEW_VERSION=$1
 BUMP_BRANCH="${NEW_VERSION}-version-bump"
+ISCSC_REMOTE=$(git remote -v | grep 'git@github.com:iScsc/iscsc.fr.git' | awk '{print $1}' | head --lines 1)
 
+# ...and checkout on main to create a version bump branch
+echo "[+] Checkout on ${ISCSC_REMOTE}/main"
+git checkout ${ISCSC_REMOTE}/main
+echo "[+] switching to ${BUMP_BRANCH}"
+git switch -c ${BUMP_BRANCH}
 
 echo "[+] Current version is '${CURRENT}'"
 

--- a/bump.sh
+++ b/bump.sh
@@ -11,7 +11,7 @@ fi
 
 # Check that required binaries are installed
 for package in semver git npm; do
-	if [ ! -f "/usr/bin/$package" ]; then
+	if [ ! $(which $package) ]; then
 		echo "[-] `$package` is needed to bump version"
 		exit 1
 	fi

--- a/bump.sh
+++ b/bump.sh
@@ -30,7 +30,7 @@ if [ ! "$1" = "$(semver $1)" ]; then
 fi
 
 # Check that git working directory is clean...
-if [ -n "$(git status -s --untracked-files=no)" ]; then
+if [ -n "$(git status --short --untracked-files=no)" ]; then
 	echo "[-] git working directory isn't clean"
 	exit 1
 fi

--- a/bump.sh
+++ b/bump.sh
@@ -46,7 +46,7 @@ ISCSC_REMOTE=$(git remote -v | grep 'git@github.com:iScsc/iscsc.fr.git' | awk '{
 # ----------- Version checking -----------
 
 # Check if targeted version is > than current
-echo "[+] Current version is '${CURRENT}'"
+echo "[+] Current version is '${CURRENT_VERSION}'"
 if [ ! $(semver "${NEW_VERSION}" -r ">${CURRENT_VERSION}") ]; then
 	echo "[-] '${NEW_VERSION}'<='${CURRENT_VERSION}', '${NEW_VERSION}' isn't accepted as new version."
 	exit 1

--- a/bump.sh
+++ b/bump.sh
@@ -24,7 +24,7 @@ for package in ${dependencies[@]}; do
 done
 
 # Check that supplied version is semantically correct
-if [ ! "$1" = "$(/usr/bin/semver $1)" ]; then
+if [ ! "$1" = "$(semver $1)" ]; then
 	echo "[-] $1 is not a valid version number according to semver"
 	exit 1
 fi

--- a/bump.sh
+++ b/bump.sh
@@ -64,15 +64,18 @@ echo "[+] switching to ${BUMP_BRANCH}"
 # ----------- Version Bump -----------
 
 echo '[+] Bumping `frontend`'
-cd frontend
-[ -z "$DRY_RUN" ] && npm version "${NEW_VERSION}" --no-git-tag-version
+$(
+	cd frontend
+	[ -z "$DRY_RUN" ] && npm version "${NEW_VERSION}" --no-git-tag-version
+)
 echo '[+] Bumping `backend`'
-cd ../backend
-[ -z "$DRY_RUN" ] && npm version "${NEW_VERSION}" --no-git-tag-version
+$(
+	cd backend
+	[ -z "$DRY_RUN" ] && npm version "${NEW_VERSION}" --no-git-tag-version
+)
 
 echo '[+] Commiting `frontend` and `backend` bump'
 [ -z "$DRY_RUN" ] && git commit -m "Bump frontend and backend versions to ${NEW_VERSION}"
 
 echo '[+] Bumping `root`'
-cd ..
 [ -z "$DRY_RUN" ] && npm version "${NEW_VERSION}" -m "Bump to version %s"

--- a/bump.sh
+++ b/bump.sh
@@ -51,22 +51,22 @@ echo "[+] '${NEW_VERSION}'>'$CURRENT', '${NEW_VERSION}' is accepted as new versi
 
 # ...and checkout on main to create a version bump branch
 echo "[+] Checkout on ${ISCSC_REMOTE}/main"
-git checkout ${ISCSC_REMOTE}/main
+[ -z "$DRY_RUN" ] && git checkout ${ISCSC_REMOTE}/main
 echo "[+] switching to ${BUMP_BRANCH}"
-git switch -c ${BUMP_BRANCH}
+[ -z "$DRY_RUN" ] && git switch -c ${BUMP_BRANCH}
 
 # ----------- Version Bump -----------
 
 echo '[+] Bumping `frontend`'
 cd frontend
-npm version "${NEW_VERSION}" --no-git-tag-version
+[ -z "$DRY_RUN" ] && npm version "${NEW_VERSION}" --no-git-tag-version
 echo '[+] Bumping `backend`'
 cd ../backend
-npm version "${NEW_VERSION}" --no-git-tag-version
+[ -z "$DRY_RUN" ] && npm version "${NEW_VERSION}" --no-git-tag-version
 
 echo '[+] Commiting `frontend` and `backend` bump'
-git commit -m "Bump frontend and backend versions to ${NEW_VERSION}"
+[ -z "$DRY_RUN" ] && git commit -m "Bump frontend and backend versions to ${NEW_VERSION}"
 
 echo '[+] Bumping `root`'
 cd ..
-npm version "${NEW_VERSION}" -m "Bump to version %s"
+[ -z "$DRY_RUN" ] && npm version "${NEW_VERSION}" -m "Bump to version %s"

--- a/bump.sh
+++ b/bump.sh
@@ -82,6 +82,7 @@ echo '[+] Bumping `root`'
 
 echo '[+] Pushing branch and new version tag'
 echo "[~] pushing to \`${ISCSC_REMOTE}\` please type your passphrase/password if required:"
-[ -z "$DRY_RUN" ] && {git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION} || echo "[-] push failed, you can push with \`git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION}\`"}
+[ -z "$DRY_RUN" ] && { git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION} || echo "[-] push failed, you can push with \`git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION}\`"; }
 
 echo '[!] `npm install` has been run during the bump, you MUST review the changes during PR review to ensure package.json and package-lock.json where compatible!!!'
+

--- a/bump.sh
+++ b/bump.sh
@@ -82,6 +82,6 @@ echo '[+] Bumping `root`'
 
 echo '[+] Pushing branch and new version tag'
 echo "[~] pushing to \`${ISCSC_REMOTE}\` please type your passphrase/password if required:"
-[ -z "$DRY_RUN" ] && git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION} || echo "[-] push failed, you can push with \`git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION}\`"
+[ -z "$DRY_RUN" ] && {git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION} || echo "[-] push failed, you can push with \`git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION}\`"}
 
 echo '[!] `npm install` has been run during the bump, you MUST review the changes during PR review to ensure package.json and package-lock.json where compatible!!!'

--- a/bump.sh
+++ b/bump.sh
@@ -9,10 +9,16 @@ if [ "$#" != "1" ]; then
 	exit 1
 fi
 
+dependencies=(
+	semver
+	git
+	npm
+)
+
 # Check that required binaries are installed
-for package in semver git npm; do
+for package in ${dependencies[@]}; do
 	if [ ! $(which $package) ]; then
-		echo "[-] `$package` is needed to bump version"
+		echo "[-] All of '${dependencies[@]}' are needed to bump version"
 		exit 1
 	fi
 done

--- a/bump.sh
+++ b/bump.sh
@@ -39,6 +39,10 @@ npm version "$1" --no-git-tag-version
 echo '[+] Bumping `backend`'
 cd ../backend
 npm version "$1" --no-git-tag-version
+
+echo '[+] Commiting `frontend` and `backend` bump'
+git commit -m "Bump frontend and backend versions to $1"
+
 echo '[+] Bumping `root`'
 cd ..
-npm version "$1" -m "Bump to version %s" -f
+npm version "$1" -m "Bump to version %s"

--- a/bump.sh
+++ b/bump.sh
@@ -62,6 +62,7 @@ echo "[+] switching to ${BUMP_BRANCH}"
 [ -z "$DRY_RUN" ] && git switch -c ${BUMP_BRANCH}
 
 # ----------- Version Bump -----------
+# ---- Bump frontend and backend -----
 
 echo '[+] Bumping `frontend`'
 (
@@ -77,9 +78,10 @@ echo '[+] Bumping `backend`'
 echo '[+] Commiting `frontend` and `backend` bump'
 [ -z "$DRY_RUN" ] && { git commit -m "Bump frontend and backend versions to ${NEW_VERSION}" || echo "[-] Fail to commit changes"; exit 1; }
 
+# ------ Bump root and push ------
+
 echo '[+] Bumping `root`'
 [ -z "$DRY_RUN" ] && { npm version "${NEW_VERSION}" -m "Bump to version %s" || echo "[-] Fail to bump root version"; exit 1; }
-
 
 echo '[+] Pushing branch and new version tag'
 echo "[~] pushing to \`${ISCSC_REMOTE}\` please type your passphrase/password if required:"

--- a/bump.sh
+++ b/bump.sh
@@ -75,10 +75,11 @@ echo '[+] Bumping `backend`'
 )
 
 echo '[+] Commiting `frontend` and `backend` bump'
-[ -z "$DRY_RUN" ] && git commit -m "Bump frontend and backend versions to ${NEW_VERSION}"
+[ -z "$DRY_RUN" ] && { git commit -m "Bump frontend and backend versions to ${NEW_VERSION}" || echo "[-] Fail to commit changes"; exit 1; }
 
 echo '[+] Bumping `root`'
-[ -z "$DRY_RUN" ] && npm version "${NEW_VERSION}" -m "Bump to version %s"
+[ -z "$DRY_RUN" ] && { npm version "${NEW_VERSION}" -m "Bump to version %s" || echo "[-] Fail to bump root version"; exit 1; }
+
 
 echo '[+] Pushing branch and new version tag'
 echo "[~] pushing to \`${ISCSC_REMOTE}\` please type your passphrase/password if required:"

--- a/bump.sh
+++ b/bump.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-if [ -z "$1" ]; then
+if [ "$#" != "1" ]; then
+	echo "[-] Exactly one argument is needed."
+	echo '[?] Example: `./bump.sh 0.2.6`'
 	exit 1
 fi
 
@@ -26,9 +28,12 @@ if [ ! $(semver "$1" -r ">$current") ]; then
 fi
 
 echo "[+] '$1' > '$current', '$1' is accepted as new version."
+echo '[+] Bumping `frontend`'
 cd frontend
 npm version "$1" --no-git-tag-version
+echo '[+] Bumping `backend`'
 cd ../backend
 npm version "$1" --no-git-tag-version
+echo '[+] Bumping `root`'
 cd ..
 npm version "$1" -m "Bump to version %s"

--- a/bump.sh
+++ b/bump.sh
@@ -76,12 +76,12 @@ echo '[+] Bumping `backend`'
 )
 
 echo '[+] Commiting `frontend` and `backend` bump'
-[ -z "$DRY_RUN" ] && { git commit -m "Bump frontend and backend versions to ${NEW_VERSION}" || echo "[-] Fail to commit changes"; exit 1; }
+[ -z "$DRY_RUN" ] && { git commit -m "Bump frontend and backend versions to ${NEW_VERSION}" || exit 1; }
 
 # ------ Bump root and push ------
 
 echo '[+] Bumping `root`'
-[ -z "$DRY_RUN" ] && { npm version "${NEW_VERSION}" -m "Bump to version %s" || echo "[-] Fail to bump root version"; exit 1; }
+[ -z "$DRY_RUN" ] && { npm version "${NEW_VERSION}" -m "Bump to version %s" || exit 1; }
 
 echo '[+] Pushing branch and new version tag'
 echo "[~] pushing to \`${ISCSC_REMOTE}\` please type your passphrase/password if required:"

--- a/bump.sh
+++ b/bump.sh
@@ -38,7 +38,7 @@ fi
 # ----------- Variable definition -----------
 
 # Define needed variables
-CURRENT=$(npm pkg get version | sed 's/"//g')
+CURRENT_VERSION=$(npm pkg get version | sed 's/"//g')
 NEW_VERSION=$1
 BUMP_BRANCH="${NEW_VERSION}-version-bump"
 ISCSC_REMOTE=$(git remote -v | grep 'git@github.com:iScsc/iscsc.fr.git' | awk '{print $1}' | head --lines 1)
@@ -47,11 +47,11 @@ ISCSC_REMOTE=$(git remote -v | grep 'git@github.com:iScsc/iscsc.fr.git' | awk '{
 
 # Check if targeted version is > than current
 echo "[+] Current version is '${CURRENT}'"
-if [ ! $(semver "${NEW_VERSION}" -r ">$CURRENT") ]; then
-	echo "[-] '${NEW_VERSION}'<='$CURRENT', '${NEW_VERSION}' isn't accepted as new version."
+if [ ! $(semver "${NEW_VERSION}" -r ">${CURRENT_VERSION}") ]; then
+	echo "[-] '${NEW_VERSION}'<='${CURRENT_VERSION}', '${NEW_VERSION}' isn't accepted as new version."
 	exit 1
 fi
-echo "[+] '${NEW_VERSION}'>'$CURRENT', '${NEW_VERSION}' is accepted as new version."
+echo "[+] '${NEW_VERSION}'>'${CURRENT_VERSION}', '${NEW_VERSION}' is accepted as new version."
 
 # ----------- Git setup -----------
 
@@ -79,3 +79,7 @@ echo '[+] Commiting `frontend` and `backend` bump'
 
 echo '[+] Bumping `root`'
 [ -z "$DRY_RUN" ] && npm version "${NEW_VERSION}" -m "Bump to version %s"
+
+echo '[+] Pushing branch and new version tag'
+echo "[~] pushing to \`${ISCSC_REMOTE}\` please type your passphrase/password if required:"
+[ -z "$DRY_RUN" ] && git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION} || echo "[-] push failed, you can push with \`git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION}\`"

--- a/bump.sh
+++ b/bump.sh
@@ -83,3 +83,5 @@ echo '[+] Bumping `root`'
 echo '[+] Pushing branch and new version tag'
 echo "[~] pushing to \`${ISCSC_REMOTE}\` please type your passphrase/password if required:"
 [ -z "$DRY_RUN" ] && git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION} || echo "[-] push failed, you can push with \`git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION}\`"
+
+echo '[!] `npm install` has been run during the bump, you MUST review the changes during PR review to ensure package.json and package-lock.json where compatible!!!'

--- a/bump.sh
+++ b/bump.sh
@@ -18,6 +18,11 @@ if [ ! "$1" = "$(/usr/bin/semver $1)" ]; then
 	exit 1
 fi
 
+if [ -n "$(git status -s --untracked-files=no)" ]; then
+	echo "[-] git working directory isn't clean"
+	exit 1
+fi
+
 current=$(npm pkg get version | sed 's/"//g')
 
 echo "[+] Current version is '${current}'"
@@ -36,4 +41,4 @@ cd ../backend
 npm version "$1" --no-git-tag-version
 echo '[+] Bumping `root`'
 cd ..
-npm version "$1" -m "Bump to version %s"
+npm version "$1" -m "Bump to version %s" -f

--- a/bump.sh
+++ b/bump.sh
@@ -27,26 +27,30 @@ if [ -n "$(git status -s --untracked-files=no)" ]; then
 	exit 1
 fi
 
-current=$(npm pkg get version | sed 's/"//g')
+# ...define needed variables...
+CURRENT=$(npm pkg get version | sed 's/"//g')
+NEW_VERSION=$1
+BUMP_BRANCH="${NEW_VERSION}-version-bump"
 
-echo "[+] Current version is '${current}'"
 
-if [ ! $(semver "$1" -r ">$current") ]; then
-	echo "[-] '$1' <= '$current', '$1' isn't accepted as new version."
+echo "[+] Current version is '${CURRENT}'"
+
+if [ ! $(semver "${NEW_VERSION}" -r ">$CURRENT") ]; then
+	echo "[-] '${NEW_VERSION}'<='$CURRENT', '${NEW_VERSION}' isn't accepted as new version."
 	exit 1
 fi
 
-echo "[+] '$1' > '$current', '$1' is accepted as new version."
+echo "[+] '${NEW_VERSION}'>'$CURRENT', '${NEW_VERSION}' is accepted as new version."
 echo '[+] Bumping `frontend`'
 cd frontend
-npm version "$1" --no-git-tag-version
+npm version "${NEW_VERSION}" --no-git-tag-version
 echo '[+] Bumping `backend`'
 cd ../backend
-npm version "$1" --no-git-tag-version
+npm version "${NEW_VERSION}" --no-git-tag-version
 
 echo '[+] Commiting `frontend` and `backend` bump'
-git commit -m "Bump frontend and backend versions to $1"
+git commit -m "Bump frontend and backend versions to ${NEW_VERSION}"
 
 echo '[+] Bumping `root`'
 cd ..
-npm version "$1" -m "Bump to version %s"
+npm version "${NEW_VERSION}" -m "Bump to version %s"

--- a/bump.sh
+++ b/bump.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+	exit 1
+fi
+
+for package in semver git npm; do
+	if [ ! -f "/usr/bin/$package" ]; then
+		echo "[-] `$package` is needed to bump version"
+		exit 1
+	fi
+done
+
+if [ ! "$1" = "$(/usr/bin/semver $1)" ]; then
+	echo "[-] $1 is not a valid version number according to semver"
+	exit 1
+fi
+
+current=$(npm pkg get version | sed 's/"//g')
+
+echo "[+] Current version is '${current}'"
+
+if [ ! $(semver "$1" -r ">$current") ]; then
+	echo "[-] '$1' <= '$current', '$1' isn't accepted as new version."
+	exit 1
+fi
+
+echo "[+] '$1' > '$current', '$1' is accepted as new version."
+cd frontend
+npm version "$1" --no-git-tag-version
+cd ../backend
+npm version "$1" --no-git-tag-version
+cd ..
+npm version "$1" -m "Bump to version %s"

--- a/bump.sh
+++ b/bump.sh
@@ -64,12 +64,12 @@ echo "[+] switching to ${BUMP_BRANCH}"
 # ----------- Version Bump -----------
 
 echo '[+] Bumping `frontend`'
-$(
+(
 	cd frontend
 	[ -z "$DRY_RUN" ] && npm version "${NEW_VERSION}" --no-git-tag-version
 )
 echo '[+] Bumping `backend`'
-$(
+(
 	cd backend
 	[ -z "$DRY_RUN" ] && npm version "${NEW_VERSION}" --no-git-tag-version
 )

--- a/bump.sh
+++ b/bump.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 
+# Check that 1 arg has been supplied
 if [ "$#" != "1" ]; then
 	echo "[-] Exactly one argument is needed."
 	echo '[?] Example: `./bump.sh 0.2.6`'
 	exit 1
 fi
 
+# Check that required binaries are installed
 for package in semver git npm; do
 	if [ ! -f "/usr/bin/$package" ]; then
 		echo "[-] `$package` is needed to bump version"
@@ -13,11 +15,13 @@ for package in semver git npm; do
 	fi
 done
 
+# Check that supplied version is semantically correct
 if [ ! "$1" = "$(/usr/bin/semver $1)" ]; then
 	echo "[-] $1 is not a valid version number according to semver"
 	exit 1
 fi
 
+# Check that git working directory is clean...
 if [ -n "$(git status -s --untracked-files=no)" ]; then
 	echo "[-] git working directory isn't clean"
 	exit 1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "start": "env-cmd -f ../.env.development react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "version": "npm install && git add package.json package-lock.json"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
     "version": "0.1.0",
     "scripts": {
-	"version": "git add package.json",
-	"postversion": "./scripts/private/postversion_push.sh"
+	"version": "git add package.json"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,3 +1,7 @@
 {
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "scripts": {
+	    "version": "npm install && git add package.json package-lock.json",
+	    "postversion": "git push && git push --tags"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "version": "0.1.0",
     "scripts": {
-	    "version": "npm install && git add package.json package-lock.json",
-	    "postversion": "git push && git push --tags"
+	"version": "npm install && git add package.json package-lock.json",
+	"postversion": "echo '[~] pushing to `git@github.com:iScsc/iscsc.fr.git` please type your passphrase/password if required:' && git push git@github.com:iScsc/iscsc.fr.git $(git branch --show-current) v$(npm pkg get version | sed 's/\"//g') || echo \"[-] push failed, you can push with 'git push git@github.com:iScsc/iscsc.fr.git $(git branch --show-current) v$(npm pkg get version | sed 's/\"//g')'\""
     }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
     "version": "0.1.0",
     "scripts": {
 	"version": "git add package.json",
-	"postversion": "echo '[~] pushing to `git@github.com:iScsc/iscsc.fr.git` please type your passphrase/password if required:' && git push git@github.com:iScsc/iscsc.fr.git $(git branch --show-current) v$(npm pkg get version | sed 's/\"//g') || echo \"[-] push failed, you can push with 'git push git@github.com:iScsc/iscsc.fr.git $(git branch --show-current) v$(npm pkg get version | sed 's/\"//g')'\""
+	"postversion": "./scripts/private/postversion_push.sh"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "version": "0.1.0",
     "scripts": {
-	"version": "npm install && git add package.json package-lock.json",
+	"version": "git add package.json",
 	"postversion": "echo '[~] pushing to `git@github.com:iScsc/iscsc.fr.git` please type your passphrase/password if required:' && git push git@github.com:iScsc/iscsc.fr.git $(git branch --show-current) v$(npm pkg get version | sed 's/\"//g') || echo \"[-] push failed, you can push with 'git push git@github.com:iScsc/iscsc.fr.git $(git branch --show-current) v$(npm pkg get version | sed 's/\"//g')'\""
     }
 }

--- a/scripts/private/postversion_push.sh
+++ b/scripts/private/postversion_push.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+BRANCH=$(git branch --show-current)
+CURRENT_VERSION=$(npm pkg get version | sed 's/\"//g')
+REMOTE='git@github.com:iScsc/iscsc.fr.git'
+
+echo "[~] pushing to \`${REMOTE}\` please type your passphrase/password if required:"
+git push ${REMOTE} ${BRANCH} v${CURRENT_VERSION} || echo "[-] push failed, you can push with \`git push ${REMOTE} ${BRANCH} v${CURRENT_VERSION}\`"

--- a/scripts/private/postversion_push.sh
+++ b/scripts/private/postversion_push.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-BRANCH=$(git branch --show-current)
-CURRENT_VERSION=$(npm pkg get version | sed 's/\"//g')
-REMOTE='git@github.com:iScsc/iscsc.fr.git'
-
-echo "[~] pushing to \`${REMOTE}\` please type your passphrase/password if required:"
-git push ${REMOTE} ${BRANCH} v${CURRENT_VERSION} || echo "[-] push failed, you can push with \`git push ${REMOTE} ${BRANCH} v${CURRENT_VERSION}\`"


### PR DESCRIPTION
**Context:**
#19 brought the first version bump for the iScsc website. However, this one was achieved manually as described in the [wiki page](https://github.com/iScsc/iscsc.fr/wiki/Version-bump-procedure) but this procedure wasn't expected to last long.  

**Problem:**
The version bump, even if its procedure should be described, shouldn't be achieved manually.

**Solution:**
I then looked for automatic tools to bump version of software and especially JS, node.js and website software.  
I found:
 - [Bump'R](https://github.com/noirbizarre/bumpr) designed for `python`
 - [npm-version](https://docs.npmjs.com/cli/v8/commands/npm-version) that is `npm` native so very interesting
 - [version-bump](https://github.com/theogravity/version-bump) --> I didn't test it :confused: 
 - [release-it](https://github.com/release-it/release-it) That looks really promising!

So I first went with `npm-version` because it seems like the more reliable and simple, and I built a `sh` script around it.  

**Script details:**
The script takes one argument which is the new version and apply it to `package.json`, `frontend/package.json` and `backend/package.json`.
The script will *in order*:
 - check that: 
   - needed packages are installed: `semver` (from `npm`), `npm`, `git`
   - supplied version is semantically correct and > than current
   - working directory is clean
 - checkout on `main` and switch to a new branch *I'm not quite convinced of that part, I would like your opinion*
 - **bump versions**
 - run `npm install` to update the `*-lock.json`s
 - commit `frontend` and `backend` together then **commit and tag** root separately 
 - try to push to remote

It partially relies on `package.json` `script`s to do this job as well as `npm version`!  

**Caveats, Limitations and Testing:**
Currently the script is safe, I think, I tried to write it without assuming anything about the user current project state but you may find some mistakes :confused:   
I must say that the output isn't the clearer you ever saw but it does the job.  
**You can't** fully test it right now, because it will checkout on main and then don't have the right `package.json`s scripts state (it won't commit and output an error because of this when bumping root).
**It has** a "dry run" mode to test it without touching the user's repo: try `DRY_RUN=foo ./bump 0.1.1`

**What's next?**  
I don't think that this script will stays as it is for long, right after finishing to write this PR I'll go try `release-it`, but this is a first step!