### PR TITLE
FEATURE: add flag support to the `gpg-share` script

### DIFF
--- a/scripts/gpg-share.sh
+++ b/scripts/gpg-share.sh
@@ -89,9 +89,8 @@ check_users() {
 
   # check if each of the "user" is in the keyring
   invalid=0
-  for _user in "${users[@]}";
+  for user in "${users[@]}";
   do
-      user=$(echo -n "$_user")
       nb_ids=$(gpg --quiet --list-keys "$user" 2> /dev/null | grep "^uid" | wc -l)
       case "$nb_ids" in
         0 ) log_warning "'$user' not found in the keyring..."; invalid=1 ;;
@@ -115,9 +114,8 @@ encrypt () {
   directory="$2"
   shift 2
   users=("$@")
-  for _user in "${users[@]}";
+  for user in "${users[@]}";
   do
-      user=$(echo -n "$_user")
       log_info "encrypting '$file' for '$user' inside '$directory'..."
       output=$(echo "$directory/$file.$user.asc" | sed 's/\s\+/-/g')
       gpg --verbose --recipient "$user" --encrypt --armor --output "$output" "$file"

--- a/scripts/gpg-share.sh
+++ b/scripts/gpg-share.sh
@@ -31,6 +31,8 @@ DEPENDENCIES=(
   tar
 )
 
+USAGE="gpg-share [-h]"
+
 
 # TODO: documentation
 check_dependencies () {
@@ -61,16 +63,6 @@ check_pwd () {
 }
 
 
-check_dependencies
-check_pwd
-
-# get the version
-VERSION=$(npm pkg get version | sed 's/"//g')
-
-# build the archive name
-ARCHIVE="keys-${VERSION}.tar"
-
-
 # TODO: documentation
 check_file () {
   [ -z "$1" ] && {
@@ -83,17 +75,6 @@ check_file () {
     exit 1
   }
 }
-
-
-file="$1"; shift 1
-check_file "$file"
-
-if [ -n "$USER_FILE" ]; then
-  check_file "$USER_FILE"
-  readarray users < "$USER_FILE"
-else
-  users=($@)
-fi
 
 
 # TODO: documentation
@@ -125,12 +106,6 @@ check_users() {
 }
 
 
-check_users
-
-DUMP_DIR=$(mktemp -u "/tmp/gpg-share-XXXXXX")
-mkdir -p "$DUMP_DIR"
-
-
 # TODO: documentation
 encrypt () {
   for _user in "${users[@]}";
@@ -156,5 +131,71 @@ archive () {
 }
 
 
-encrypt
-archive
+# parse the arguments.
+OPTIONS=$(getopt -o h --long help -n 'gpg-share' -- "$@")
+if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
+eval set -- "$OPTIONS"
+
+
+usage () {
+  echo "Usage: $USAGE"
+  echo "Type -h or --help for the full help."
+  exit 0
+}
+
+
+help () {
+  echo "gpg-share:"
+  echo "     TODO."
+  echo ""
+  echo "Usage:"
+  echo "     $USAGE"
+  echo ""
+  echo "Options:"
+  echo "     -h/--help               shows this help."
+  exit 0
+}
+
+
+main () {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h | --help ) help ;;
+      -- ) shift; break ;;
+      * ) break ;;
+    esac
+  done
+
+  echo "ACTUAL STUFF COMING SOON!"
+  exit 0
+
+  check_dependencies
+  check_pwd
+
+  # get the version
+  VERSION=$(npm pkg get version | sed 's/"//g')
+
+  # build the archive name
+  ARCHIVE="keys-${VERSION}.tar"
+
+  file="$1"; shift 1
+  check_file "$file"
+
+  if [ -n "$USER_FILE" ]; then
+    check_file "$USER_FILE"
+    readarray users < "$USER_FILE"
+  else
+    users=($@)
+  fi
+
+  check_users
+
+  DUMP_DIR=$(mktemp -u "/tmp/gpg-share-XXXXXX")
+  mkdir -p "$DUMP_DIR"
+
+  encrypt
+  archive
+}
+
+
+main "$@"

--- a/scripts/gpg-share.sh
+++ b/scripts/gpg-share.sh
@@ -139,7 +139,7 @@ archive () {
 
 
 # parse the arguments.
-OPTIONS=$(getopt -o hu:U:f: --long help,user:,users:,file -n 'gpg-share' -- "$@")
+OPTIONS=$(getopt -o hu:U:f: --long help,user:,users:,file: -n 'gpg-share' -- "$@")
 if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 eval set -- "$OPTIONS"
 

--- a/scripts/gpg-share.sh
+++ b/scripts/gpg-share.sh
@@ -66,7 +66,7 @@ check_pwd () {
 # TODO: documentation
 check_file () {
   [ -z "$1" ] && {
-    log_error "Please give a file to share as the first argument"
+    log_error 'Please give a file to share with the `-f` flag'
     usage
     exit 1
   }
@@ -82,7 +82,7 @@ check_file () {
 check_users() {
   users=("$@")
   [ "${#users[@]}" -eq 0 ] && {
-    log_error "Please give at least one gpg id after the first argument"
+    log_error 'Please give at least one gpg id with the `-u` and `-U` flags'
     usage
     exit 1
   }

--- a/scripts/gpg-share.sh
+++ b/scripts/gpg-share.sh
@@ -139,7 +139,7 @@ archive () {
 
 
 # parse the arguments.
-OPTIONS=$(getopt -o h --long help -n 'gpg-share' -- "$@")
+OPTIONS=$(getopt -o hu:U:f: --long help,user:,users:,file -n 'gpg-share' -- "$@")
 if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 eval set -- "$OPTIONS"
 
@@ -165,9 +165,19 @@ help () {
 
 
 main () {
+  users=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -h | --help ) help ;;
+      -f | --file ) file="$2"; shift 2;;
+      -u | --user ) users+=("$2"); shift 2;;
+      -U | --users ) 
+        check_file "$2"
+        readarray new_users < "$2"
+        shift 2
+        for new_user in "${new_users[@]}"; do
+          users+=("$(echo -n "$new_user")")
+        done;;
       -- ) shift; break ;;
       * ) break ;;
     esac
@@ -176,15 +186,7 @@ main () {
   check_dependencies
   check_pwd
 
-  file="$1"; shift 1
   check_file "$file"
-
-  if [ -n "$USER_FILE" ]; then
-    check_file "$USER_FILE"
-    readarray users < "$USER_FILE"
-  else
-    users=($@)
-  fi
 
   check_users "${users[@]}"
 

--- a/scripts/gpg-share.sh
+++ b/scripts/gpg-share.sh
@@ -31,7 +31,7 @@ DEPENDENCIES=(
   tar
 )
 
-USAGE="gpg-share [-h]"
+USAGE="gpg-share [-h] -f FILE {-u USER} {-U USER_FILE}"
 
 
 # TODO: documentation

--- a/scripts/gpg-share.sh
+++ b/scripts/gpg-share.sh
@@ -153,13 +153,21 @@ usage () {
 
 help () {
   echo "gpg-share:"
-  echo "     TODO."
+  echo "     a script to share a secret file with others using pgp public keys."
+  echo "     it should guide you when you make mistakes, e.g. providing a non-existing file."
   echo ""
   echo "Usage:"
   echo "     $USAGE"
   echo ""
   echo "Options:"
   echo "     -h/--help               shows this help."
+  echo "     -f/--file               the secret file to share."
+  echo "     -u/--user               a single user id in the keyring."
+  echo "                               can be used multiple times."
+  echo "                               supports multi-word ids inside quotes, e.g. \"John Smith\"."
+  echo "     -U/--users              the path to a file containing pgp ids."
+  echo "                               should contain exactly one valid pgp id per line."
+  echo "                               can be used multiple times."
   exit 0
 }
 

--- a/scripts/gpg-share.sh
+++ b/scripts/gpg-share.sh
@@ -91,11 +91,11 @@ check_users() {
   invalid=0
   for user in "${users[@]}";
   do
-      nb_ids=$(gpg --quiet --list-keys "$user" 2> /dev/null | grep "^uid" | wc -l)
+      nb_ids=$(gpg --quiet --list-keys --with-colons "$user" 2> /dev/null | grep "^uid" | wc -l)
       case "$nb_ids" in
         0 ) log_warning "'$user' not found in the keyring..."; invalid=1 ;;
         1 )
-          id=$(gpg --quiet --list-keys "$user" | grep uid -B1 | head -n 1 | awk '{print $1}');
+          id=$(gpg --quiet --list-keys --with-colons "$user" | grep "^pub" -A1 | grep "^fpr" | awk -F ":" '{print $10}');
           log_success "key $id found for '$user'"
           ;;
         * ) log_warning "too many ids found for '$user' in keyring ($nb_ids)"; invalid=1 ;;

--- a/scripts/gpg-share.sh
+++ b/scripts/gpg-share.sh
@@ -108,26 +108,30 @@ check_users() {
 
 # TODO: documentation
 encrypt () {
+  file="$1"
+  directory="$2"
   for _user in "${users[@]}";
   do
       user=$(echo -n "$_user")
-      log_info "encrypting '$file' for '$user' inside '$DUMP_DIR'..."
-      output=$(echo "$DUMP_DIR/$file.$user.asc" | sed 's/\s\+/-/g')
+      log_info "encrypting '$file' for '$user' inside '$directory'..."
+      output=$(echo "$directory/$file.$user.asc" | sed 's/\s\+/-/g')
       gpg --verbose --recipient "$user" --encrypt --armor --output "$output" "$file"
   done
-  log_success "all encrypted file have been saved inside '$DUMP_DIR'"
+  log_success "all encrypted file have been saved inside '$directory'"
 }
 
 
 # TODO: documentation
 archive () {
+  directory="$1"
+  name="$2"
   log_info "storing files in archive"
   # subshell here to avoid archiving the paths to the .asc files
   (
-    cd "$DUMP_DIR"
-    tar cvf "$ARCHIVE" $(find . -type f)
+    cd "$directory"
+    tar cvf "$name" $(find . -type f)
   )
-  cp "$DUMP_DIR/$ARCHIVE" .
+  cp "$directory/$name" .
 }
 
 
@@ -166,17 +170,8 @@ main () {
     esac
   done
 
-  echo "ACTUAL STUFF COMING SOON!"
-  exit 0
-
   check_dependencies
   check_pwd
-
-  # get the version
-  VERSION=$(npm pkg get version | sed 's/"//g')
-
-  # build the archive name
-  ARCHIVE="keys-${VERSION}.tar"
 
   file="$1"; shift 1
   check_file "$file"
@@ -188,13 +183,16 @@ main () {
     users=($@)
   fi
 
-  check_users
+  # check_users
 
-  DUMP_DIR=$(mktemp -u "/tmp/gpg-share-XXXXXX")
-  mkdir -p "$DUMP_DIR"
+  archive_directory=$(mktemp -u "/tmp/gpg-share-XXXXXX")
+  mkdir -p "$archive_directory"
 
-  encrypt
-  archive
+  # encrypt "$file" "$directory"
+
+  repo_version=$(npm pkg get version | sed 's/"//g')
+  archive_name="keys-${repo_version}.tar"
+  # archive "$archive_directory" "$archive_name"
 }
 
 

--- a/scripts/gpg-share.sh
+++ b/scripts/gpg-share.sh
@@ -79,6 +79,7 @@ check_file () {
 
 # TODO: documentation
 check_users() {
+  users=("$@")
   [ "${#users[@]}" -eq 0 ] && {
     log_error "Please give at least one gpg id after the first argument"
     exit 1
@@ -110,6 +111,8 @@ check_users() {
 encrypt () {
   file="$1"
   directory="$2"
+  shift 2
+  users=("$@")
   for _user in "${users[@]}";
   do
       user=$(echo -n "$_user")
@@ -183,16 +186,16 @@ main () {
     users=($@)
   fi
 
-  # check_users
+  check_users "${users[@]}"
 
   archive_directory=$(mktemp -u "/tmp/gpg-share-XXXXXX")
   mkdir -p "$archive_directory"
 
-  # encrypt "$file" "$directory"
+  encrypt "$file" "$archive_directory" "${users[@]}"
 
   repo_version=$(npm pkg get version | sed 's/"//g')
   archive_name="keys-${repo_version}.tar"
-  # archive "$archive_directory" "$archive_name"
+  archive "$archive_directory" "$archive_name"
 }
 
 

--- a/scripts/gpg-share.sh
+++ b/scripts/gpg-share.sh
@@ -67,6 +67,7 @@ check_pwd () {
 check_file () {
   [ -z "$1" ] && {
     log_error "Please give a file to share as the first argument"
+    usage
     exit 1
   }
 
@@ -82,6 +83,7 @@ check_users() {
   users=("$@")
   [ "${#users[@]}" -eq 0 ] && {
     log_error "Please give at least one gpg id after the first argument"
+    usage
     exit 1
   }
 

--- a/scripts/gpg-share.sh
+++ b/scripts/gpg-share.sh
@@ -173,11 +173,17 @@ help () {
 
 
 main () {
+  file=""
   users=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -h | --help ) help ;;
-      -f | --file ) file="$2"; shift 2;;
+      -f | --file )
+        [ -n "$file" ] && {
+          log_error "cannot set file multiple times with -f"
+          exit 1
+        }
+        file="$2"; shift 2;;
       -u | --user ) users+=("$2"); shift 2;;
       -U | --users ) 
         check_file "$2"


### PR DESCRIPTION
This PR adds a bunch of flags to the `gpg-share.sh` script, to make its use both documented and easier.
This PR will close #37.

##  the changes
- **f55d62a..dfa0b31**: add flag support using the `getopt` command
:point_right: on dfa0b31, the script is equivalent to the one on 6d7a9f6, but with empty flag support
  - `git diff f55d62a^..dfa0b31` to see the diff
- **e83d952**: allow the user to pass the file and the list of users with `-f`, `-u` and `-U`
do not use `USER_FILE` anymore
  - `git show e83d952` to see the diff
- **da112f9..e30043d**: dedicated to the help and the usage
removes the `echo -n` lines thanks to the new better array system, see 9ec42b9 for details
  - `git diff da112f9^..e30043d:` to see the diff

## details about the usage
one can see the following
```bash
> ./scripts/gpg-share.sh -h
gpg-share:
     a script to share a secret file with others using pgp public keys.
     it should guide you when you make mistakes, e.g. providing a non-existing file.

Usage:
     gpg-share [-h] -f FILE {-u USER} {-U USER_FILE}

Options:
     -h/--help               shows this help.
     -f/--file               the secret file to share.
     -u/--user               a single user id in the keyring.
                               can be used multiple times.
                               supports multi-word ids inside quotes, e.g. "John Smith".
     -U/--users              the path to a file containing pgp ids.
                               should contain exactly one valid pgp id per line.
                               can be used multiple times.
```
the `-u` and `-U` flags can be used multiple times, and they are meant to be used as such
to avoid word splitting issues with `bash`, i chose to implement the flag parsing as follows:
- the user passes one user at the time with a separate `-u` each time. this allows to write `./scripts/gpg-share.sh -u "Alexandre Tullot"` and the id won't be split :star_struck: 
- to pass multiple users, simply write something like `./scripts/gpg-share.sh -u amtoine -u "Alexandre Tullot"`

this is the meaning of the `{ ... }` in the usage!
they mean the `-u` and `-U` flags can be used any number of times :+1: 

## what i did not do for now
- **`-u` and `-U` with multiple user ids**: this is too complex in `bash` according to me, i think this would require way to much work and might even be ambiguous as `bash` does not have typed variables, e.g. `-u amtoine "Alexandre Tullot" foo` might be treated as `"amtoine Alexandre Tullot foo"` :thinking:
in the end, i think the `-u SINGLE_USER_ID` syntax is as easy to write and far less ambiguous than the multi-id one
- **the `--check-keyring (-k)` option**: i do not know really what to check there :confused: 
- **exectute from `./scripts/`**: this was not the focus of this PR, so i did not change anything in that direction :+1: 
- **strong array checks**: i did not implement strong checks on the array of users, for instance, an id might appear multiple times in the array, e.g. with `-u amtoine -u amtoine` and the script will encrypt the secret file twice and overwrite previous encryptions for the `amtoine` user