### PR TITLE
0.1.1 version bump

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "iscsc.fr-backend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iscsc.fr-backend",
-      "version": "0.1.0",
-      "license": "ISC",
+      "version": "0.1.1",
+      "license": "GPL-3.0-only",
       "dependencies": {
         "bcrypt": "^5.0.1",
         "cors": "^2.8.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iscsc.fr-backend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Backend of the iscsc.fr website",
   "private": true,
   "main": "app.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iscsc.fr-frontend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iscsc.fr-frontend",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "proxy": "http://localhost:3001",
   "name": "iscsc.fr-frontend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Frontend of the iscsc.fr website",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "name": "iscsc.fr",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "The iScsc website",
     "private": true,
     "scripts": {
-	    "version": "git add package.json"
+        "version": "git add package.json"
     }
 }


### PR DESCRIPTION
Here it is, the version bump to `0.1.1`!
See the [milestone](https://github.com/iScsc/iscsc.fr/milestone/3) for detailed changes!
Of course a release will be made right after this merge, and the production website will be updated! 

*PS:
this is the first automatic bump with `./scripts/bump.sh` and I must say it worked as expected, so well done everyone!!*