### PR TITLE
Remove intermediary commit in `bump.sh`

### DIFF
--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -150,5 +150,5 @@ log_info 'Pushing branch and new version tag'
 log_warning "pushing to \`${ISCSC_REMOTE}\` please type your passphrase/password if required:"
 [ -z "$DRY_RUN" ] && { git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION} || log_error "push failed, you can push with \`git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION}\`"; }
 
-log_error '`npm install` has been run during the bump, you MUST review the changes during PR review to ensure package.json and package-lock.json where compatible!!!'
+log_hint '`npm install` has been run during the bump, you MUST review the changes during PR review to ensure package.json and package-lock.json where compatible!!!'
 

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -122,8 +122,9 @@ log_info "'${NEW_VERSION}'>'${CURRENT_VERSION}', '${NEW_VERSION}' is accepted as
 # --------------------------------- Git setup ----------------------------------
 
 # ...and checkout on main to create a version bump branch
+# (working dir is empty check passed)
 log_info "Checkout on ${ISCSC_REMOTE}/main"
-[ -z "$DRY_RUN" ] && { git checkout ${ISCSC_REMOTE}/main || exit 1; }
+[ -z "$DRY_RUN" ] && git checkout ${ISCSC_REMOTE}/main
 log_info "switching to ${BUMP_BRANCH}"
 [ -z "$DRY_RUN" ] && git switch -c ${BUMP_BRANCH}
 

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -150,7 +150,8 @@ log_info 'Bumping `root`'
 
 log_info 'Pushing branch and bump commit'
 log_warning "pushing to \`${ISCSC_REMOTE}\` please type your passphrase/password if required:"
-[ -z "$DRY_RUN" ] && { git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION} || log_error "push failed, you can push with \`git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION}\`"; }
+PUSH_COMMAND="git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION}"
+[ -z "$DRY_RUN" ] && { $PUSH_COMMAND || log_error "push failed, you can push with \`${PUSH_COMMAND}\`"; }
 
 log_hint '`npm install` has been run during the bump, you MUST review the changes during PR review to ensure package.json and package-lock.json where compatible!!!'
 

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -123,7 +123,7 @@ log_info "'${NEW_VERSION}'>'${CURRENT_VERSION}', '${NEW_VERSION}' is accepted as
 
 # ...and checkout on main to create a version bump branch
 log_info "Checkout on ${ISCSC_REMOTE}/main"
-[ -z "$DRY_RUN" ] && git checkout ${ISCSC_REMOTE}/main || exit 1
+[ -z "$DRY_RUN" ] && { git checkout ${ISCSC_REMOTE}/main || exit 1; }
 log_info "switching to ${BUMP_BRANCH}"
 [ -z "$DRY_RUN" ] && git switch -c ${BUMP_BRANCH}
 

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -141,9 +141,6 @@ log_info 'Bumping `backend`'
 	[ -z "$DRY_RUN" ] && npm version "${NEW_VERSION}" --no-git-tag-version
 )
 
-log_info 'Commiting `frontend` and `backend` bump'
-[ -z "$DRY_RUN" ] && { git commit -m "Bump frontend and backend versions to ${NEW_VERSION}" || exit 1; }
-
 # ----------------------------- Bump root and push -----------------------------
 
 log_info 'Bumping `root`'

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -145,9 +145,10 @@ log_info 'Bumping `backend`'
 # ----------------------------- Bump root and push -----------------------------
 
 log_info 'Bumping `root`'
-[ -z "$DRY_RUN" ] && { npm version "${NEW_VERSION}" -m "Bump to version %s" || exit 1; }
+[ -z "$DRY_RUN" ] && { npm version "${NEW_VERSION}" --no-git-tag-version || exit 1; }
+[ -z "$DRY_RUN" ] && { git commit -m "Bump to version ${NEW_VERSION}" || exit 1; }
 
-log_info 'Pushing branch and new version tag'
+log_info 'Pushing branch and bump commit'
 log_warning "pushing to \`${ISCSC_REMOTE}\` please type your passphrase/password if required:"
 [ -z "$DRY_RUN" ] && { git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION} || log_error "push failed, you can push with \`git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION}\`"; }
 


### PR DESCRIPTION
This PR simply implement one of the decision that was taken after last release: 
 - the automatic bump script shouldn't commit twice and shouldn't tag
It also corrects minor problems.
Once the PR is merge, the documentation will be updated accordingly

Another bigger PR is coming that should implement the other decision:
 -  add `patch` `minor` and `major` subcommands to the script to easily bump version *Ex: currently (at 0.1.1) `./bump.sh patch` would be equivalent as `./bump.sh 0.1.2`*
(and we'll probably add better arguments handling)