### PR TITLE
Add subcommands to bump script

### DIFF
--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -139,7 +139,7 @@ git_setup () {
 	# ...and checkout on main to create a version bump branch
 	# (working dir is empty check passed)
 	log_info "Checkout on ${iscsc_remote_name}/main"
-	[ -z "$DRY_RUN" ] && { git checkout ${iscsc_remote_name}/main || exit 1; }
+	[ -z "$DRY_RUN" ] && { git checkout ${iscsc_remote_name}/main --detach || exit 1; }
 	log_info "switching to ${bump_branch}"
 	[ -z "$DRY_RUN" ] && { git switch -c ${bump_branch} || exit 1; }
 }

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -129,8 +129,8 @@ check_iscsc_remote () {
 # --------------------------------- Git setup ----------------------------------
 
 get_remote () {
-	git remote -v | grep "${SSH_REMOTE}" >/dev/null && { echo "${SSH_REMOTE}"; exit; }
-	git remote -v | grep "${HTTPS_REMOTE}" >/dev/null && { echo "${HTTPS_REMOTE}"; exit; }
+	git remote -v | grep --ignore-case "${SSH_REMOTE}" >/dev/null && { echo "${SSH_REMOTE}"; exit; }
+	git remote -v | grep --ignore-case "${HTTPS_REMOTE}" >/dev/null && { echo "${HTTPS_REMOTE}"; exit; }
 }
 
 git_setup () {
@@ -260,7 +260,7 @@ main () {
 	check_iscsc_remote "${ISCSC_REMOTE}"
 
 	# Define iScsc remote name if it exists and log new version
-	ISCSC_REMOTE_NAME=$(git remote -v | grep "${ISCSC_REMOTE}" | awk '{print $1}' | head --lines 1)
+	ISCSC_REMOTE_NAME=$(git remote -v | grep --ignore-case "${ISCSC_REMOTE}" | awk '{print $1}' | head --lines 1)
 	log_info "'${NEW_VERSION}'>'${CURRENT_VERSION}', '${NEW_VERSION}' is accepted as new version."
 
 	# Setup git branch

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -71,6 +71,11 @@ check_clean_git_working_dir () {
 # Check that supplied version is semantically correct
 check_version_semantics () {
 	local version="$1"
+	if [ -z "${version}" ]; then
+		log_error "You provided a wrong argument, version can't be computed"
+		usage
+		exit 1
+	fi
 	if [ "${version}" != "$(semver ${version})" ]; then
 		log_error "${version} is not a valid version number according to semver"
 		exit 1

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -22,6 +22,10 @@ log_warning () { log_any "33" "~" "$1"; }
 log_hint    () { log_any "34" "?" "$1"; }
 log_info    () { log_any "35" "i" "$1"; }
 
+break_down_version () {
+    echo ${1//./ }
+}
+
 # -------------------------------- Basic Checks --------------------------------
 
 # Check that current directory is repo root

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -237,8 +237,8 @@ main () {
 	check_clean_git_working_dir
 
 	# Define version variables
-	NEW_VERSION=$(bump_${COMMAND} ${CURRENT_VERSION})
 	CURRENT_VERSION=$(npm pkg get version | sed 's/"//g')
+	NEW_VERSION=$(bump_${COMMAND} ${CURRENT_VERSION})
 
 	# Define git variables
 	BUMP_BRANCH="${NEW_VERSION}-version-bump"

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -92,6 +92,8 @@ check_version_and_tag_consistency () {
 	local json_version="$1"
 	tagged_commit=$(git rev-list --tags --max-count=1)
 	tag_version=$(git describe --tags $tagged_commit)
+	# remove the 'v' before the version
+	tag_version=$(semver $tag_version)
 
 	if [ "$json_version" != "$tag_version" ]; then
 		log_error "tag '$tag_version' is not consistent with project version '${json_version}' !!!"

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -23,7 +23,7 @@ log_info    () { log_any "35" "i" "$1"; }
 
 # -------------------------------- Basic Checks --------------------------------
 
-# check that current directory is repo root
+# Check that current directory is repo root
 check_pwd () {
 	root="$(dirname $(realpath $(dirname "$0")))"
 	[ "$root" != "$(pwd)" ] && {

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -8,6 +8,7 @@ DEPENDENCIES=(
 
 # Variables
 NB_ARGS="$#"
+USAGE="bump.sh [-h] -p|-m|-M"
 
 # ------------------------------- Tool functions -------------------------------
 
@@ -40,9 +41,7 @@ check_arg () {
 	local nb_args="$1"
 	if [ "${nb_args}" -ne "1" ]; then
 		log_error "Exactly one argument is needed, got ${nb_args}."
-		log_hint 'Example: `./bump.sh 0.2.6`'
-		log_hint "see https://github.com/iScsc/iscsc.fr/wiki/Version-bump-procedure#automatic-version-bump for full documentation"
-		exit 1
+		usage
 	fi
 	[ -n "$DRY_RUN" ] && log_ok "Only argument has been given OK"
 }
@@ -136,6 +135,15 @@ bump_root () {
 	log_info 'Bumping `root`'
 	[ -z "$DRY_RUN" ] && { npm version "${new_version}" --no-git-tag-version || exit 1; }
 	[ -z "$DRY_RUN" ] && { git commit -m "Bump to version ${new_version}" || exit 1; }
+}
+
+# -- Help and usage --
+
+usage () {
+	echo "Usage: $USAGE"
+	echo "Type -h or --help for the full help."
+	echo "See https://github.com/iScsc/iscsc.fr/wiki/Version-bump-procedure#automatic-version-bump for full documentation"
+	exit 0
 }
 
 # -------------------------------- Main Section --------------------------------

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -83,6 +83,19 @@ check_version_semantics () {
 	[ -n "$DRY_RUN" ] && log_ok "Provided version '${version}' is semantically correct OK"
 }
 
+# Check that last tag and current version are consistent
+check_version_and_tag_consistency () {
+	local json_version="$1"
+	tagged_commit=$(git rev-list --tags --max-count=1)
+	tag_version=$(git describe --tags $tagged_commit)
+
+	if [ "$json_version" != "$tag_version" ]; then
+		log_error "tag '$tag_version' is not consistent with project version '${json_version}' !!!"
+		exit 1
+	fi
+	[ -n "$DRY_RUN" ] && log_ok "tag and project version are consistent OK"
+}
+
 # Check that targeted version is > than current
 check_version_greater () {
 	log_info "Current version is '${CURRENT_VERSION}'"
@@ -198,6 +211,7 @@ main () {
 
 	# Run all advanced checks
 	check_version_semantics "${NEW_VERSION}"
+	check_version_and_tag_consistency "${CURRENT_VERSION}"
 	check_version_greater
 	check_iscsc_remote "${ISCSC_REMOTE}"
 

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -147,9 +147,23 @@ main () {
 	check_dependencies
 	check_clean_git_working_dir
 
-	# Define needed variables
-	NEW_VERSION="$1"; shift 1;
+	# Define version variables
+	NEW_VERSION=""
 	CURRENT_VERSION=$(npm pkg get version | sed 's/"//g')
+
+	# Extract new version from arguments
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			-h | --help ) help ;;
+			-p | --patch ) NEW_VERSION=$(bump_patch ${CURRENT_VERSION}; shift 1;;
+			-m | --minor ) NEW_VERSION=$(bump_minor ${CURRENT_VERSION}; shift 1;;
+			-M | --major ) NEW_VERSION=$(bump_major ${CURRENT_VERSION}; shift 1;;
+			-- ) shift; break ;;
+			* ) break ;;
+		esac
+	done
+
+	# Define git variables
 	BUMP_BRANCH="${NEW_VERSION}-version-bump"
 	ISCSC_REMOTE=$(git remote -v | grep 'git@github.com:iScsc/iscsc.fr.git' | awk '{print $1}' | head --lines 1)
 
@@ -175,5 +189,10 @@ main () {
 
 	log_hint '`npm install` has been run during the bump, you MUST review the changes during PR review to ensure package.json and package-lock.json where compatible!!!'
 }
+
+# parse the arguments.
+OPTIONS=$(getopt -o hpmM --long help,patch,minor,major -n 'bump' -- "$@")
+if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
+eval set -- "$OPTIONS"
 
 main "$@"

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -184,6 +184,34 @@ help () {
 	exit 0
 }
 
+# -- Version Bump Functions --
+
+bump_major () {
+    bits=($(break_down_version $1))
+    major=${bits[0]}
+
+    echo "$((major+1)).0.0"
+}
+
+
+bump_minor () {
+    bits=($(break_down_version $1))
+    major=${bits[0]}
+    minor=${bits[1]}
+
+    echo "$major.$((minor+1)).0"
+}
+
+
+bump_patch () {
+    bits=($(break_down_version $1))
+    major=${bits[0]}
+    minor=${bits[1]}
+    patch=${bits[2]}
+
+    echo "$major.$minor.$((patch+1))"
+}
+
 # -------------------------------- Main Section --------------------------------
 
 main () {

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -8,7 +8,7 @@ DEPENDENCIES=(
 
 # Variables
 NB_ARGS="$#"
-USAGE="bump.sh [-h] -p|-m|-M"
+USAGE="bump.sh [-h | --help] [-p | --patch] [-m | --minor] [-M | --major]"
 
 # ------------------------------- Tool functions -------------------------------
 

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -25,6 +25,9 @@ log_hint    () { log_any "34" "?" "$1"; }
 log_info    () { log_any "35" "i" "$1"; }
 
 break_down_version () {
+	# # Exemple
+	# V=1.2.3
+	# echo ${V//./ } # 1 2 3
     echo ${1//./ }
 }
 

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -217,6 +217,19 @@ bump_patch () {
 # -------------------------------- Main Section --------------------------------
 
 main () {
+	COMMAND=""
+	# Extract new version from arguments
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			-h | --help ) help ;;
+			-p | --patch ) COMMAND="patch"; shift 1;;
+			-m | --minor ) COMMAND="minor"; shift 1;;
+			-M | --major ) COMMAND="major"; shift 1;;
+			-- ) shift; break ;;
+			* ) break ;;
+		esac
+	done
+
 	# Run all basic checks
 	check_pwd
 	check_arg "${NB_ARGS}"
@@ -224,20 +237,8 @@ main () {
 	check_clean_git_working_dir
 
 	# Define version variables
-	NEW_VERSION=""
+	NEW_VERSION=$(bump_${COMMAND} ${CURRENT_VERSION})
 	CURRENT_VERSION=$(npm pkg get version | sed 's/"//g')
-
-	# Extract new version from arguments
-	while [[ $# -gt 0 ]]; do
-		case "$1" in
-			-h | --help ) help ;;
-			-p | --patch ) NEW_VERSION=$(bump_patch ${CURRENT_VERSION}); shift 1;;
-			-m | --minor ) NEW_VERSION=$(bump_minor ${CURRENT_VERSION}); shift 1;;
-			-M | --major ) NEW_VERSION=$(bump_major ${CURRENT_VERSION}); shift 1;;
-			-- ) shift; break ;;
-			* ) break ;;
-		esac
-	done
 
 	# Define git variables
 	BUMP_BRANCH="${NEW_VERSION}-version-bump"

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -161,7 +161,7 @@ bump_root () {
 	[ -z "$DRY_RUN" ] && { git commit -m "Bump to version ${new_version}" || exit 1; }
 }
 
-# -- Help and usage --
+# ------------------------------- Help and usage -------------------------------
 
 usage () {
 	echo "Usage: $USAGE"
@@ -186,7 +186,7 @@ help () {
 	exit 0
 }
 
-# -- Version Bump Functions --
+# --------------------------- Version Bump Functions ---------------------------
 
 bump_major () {
     bits=($(break_down_version $1))

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -229,9 +229,9 @@ main () {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 			-h | --help ) help ;;
-			-p | --patch ) NEW_VERSION=$(bump_patch ${CURRENT_VERSION}; shift 1;;
-			-m | --minor ) NEW_VERSION=$(bump_minor ${CURRENT_VERSION}; shift 1;;
-			-M | --major ) NEW_VERSION=$(bump_major ${CURRENT_VERSION}; shift 1;;
+			-p | --patch ) NEW_VERSION=$(bump_patch ${CURRENT_VERSION}); shift 1;;
+			-m | --minor ) NEW_VERSION=$(bump_minor ${CURRENT_VERSION}); shift 1;;
+			-M | --major ) NEW_VERSION=$(bump_major ${CURRENT_VERSION}); shift 1;;
 			-- ) shift; break ;;
 			* ) break ;;
 		esac

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -146,6 +146,22 @@ usage () {
 	exit 0
 }
 
+help () {
+	echo "bump.sh:"
+	echo "     a script to easily bump the version of the iScsc website project."
+	echo "     it should guide you when you make mistakes, e.g. providing less or more than 1 argument."
+	echo ""
+	echo "Usage:"
+	echo "     $USAGE"
+	echo ""
+	echo "Options:"
+	echo "     -h/--help                shows this help."
+	echo "     -p/--patch               bump to patch version (1.2.3 --> 1.2.4)."
+	echo "     -m/--minor               bump to minor version (1.2.3 --> 1.3.0)."
+	echo "     -M/--major               bump to major version (1.2.3 --> 2.0.0)."
+	exit 0
+}
+
 # -------------------------------- Main Section --------------------------------
 
 main () {

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -116,12 +116,10 @@ check_version_greater () {
 check_iscsc_remote () {
 	local remote="$1"
 	if [ -z "$remote" ]; then
-		log_warning "'git@github.com:iScsc/iscsc.fr.git' remote is not in remote list, won't push"
-		PUSH="n"
-	else
-		log_ok "'iScsc/iscsc.fr' is in remote list as '$remote' OK"
-		PUSH="y"
+		log_error "'iScsc/iscsc.fr' remote is not in remote list"
+		exit 1
 	fi
+	log_ok "'iScsc/iscsc.fr' is in remote list as '$remote' OK"
 }
 
 # --------------------------------- Git setup ----------------------------------
@@ -245,7 +243,6 @@ main () {
 	# Define git variables
 	BUMP_BRANCH="${NEW_VERSION}-version-bump"
 	ISCSC_REMOTE=$(git remote -v | grep 'git@github.com:iScsc/iscsc.fr.git' | awk '{print $1}' | head --lines 1)
-	PUSH=""
 
 	# Run all advanced checks
 	check_version_semantics "${NEW_VERSION}"
@@ -262,13 +259,11 @@ main () {
 	bump_modules ${NEW_VERSION}
 	bump_root ${NEW_VERSION}
 
-	if [ "$PUSH" == "y" ]; then
-		# Try to push bump refs
-		log_info 'Pushing branch and bump commit'
-		log_warning "pushing to \`${ISCSC_REMOTE}\` please type your passphrase/password if required:"
-		PUSH_COMMAND="git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION}"
-		[ -z "$DRY_RUN" ] && { $PUSH_COMMAND || log_error "push failed, you can push with \`${PUSH_COMMAND}\`"; }
-	fi
+	# Try to push bump refs
+	log_info 'Pushing branch and bump commit'
+	log_warning "pushing to \`${ISCSC_REMOTE}\` please type your passphrase/password if required:"
+	PUSH_COMMAND="git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION}"
+	[ -z "$DRY_RUN" ] && { $PUSH_COMMAND || log_error "push failed, you can push with \`${PUSH_COMMAND}\`"; }
 
 	log_hint '`npm install` has been run during the bump, you MUST review the changes during PR review to ensure package.json and package-lock.json where compatible!!!'
 }

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -139,9 +139,9 @@ git_setup () {
 	# ...and checkout on main to create a version bump branch
 	# (working dir is empty check passed)
 	log_info "Checkout on ${iscsc_remote_name}/main"
-	[ -z "$DRY_RUN" ] && git checkout ${iscsc_remote_name}/main
+	[ -z "$DRY_RUN" ] && { git checkout ${iscsc_remote_name}/main || exit 1; }
 	log_info "switching to ${bump_branch}"
-	[ -z "$DRY_RUN" ] && git switch -c ${bump_branch}
+	[ -z "$DRY_RUN" ] && { git switch -c ${bump_branch} || exit 1; }
 }
 
 # -------------------------------- Version Bump --------------------------------

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -129,8 +129,8 @@ check_iscsc_remote () {
 # --------------------------------- Git setup ----------------------------------
 
 get_remote () {
-	git remote -v | grep "${SSH_REMOTE}" && { echo "${SSH_REMOTE}"; exit; }
-	git remote -v | grep "${HTTPS_REMOTE}" && { echo "${HTTPS_REMOTE}"; exit; }
+	git remote -v | grep "${SSH_REMOTE}" >/dev/null && { echo "${SSH_REMOTE}"; exit; }
+	git remote -v | grep "${HTTPS_REMOTE}" >/dev/null && { echo "${HTTPS_REMOTE}"; exit; }
 }
 
 git_setup () {

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -242,18 +242,18 @@ main () {
 
 	# Define git variables
 	BUMP_BRANCH="${NEW_VERSION}-version-bump"
-	ISCSC_REMOTE=$(git remote -v | grep 'git@github.com:iScsc/iscsc.fr.git' | awk '{print $1}' | head --lines 1)
+	ISCSC_REMOTE_NAME=$(git remote -v | grep 'git@github.com:iScsc/iscsc.fr.git' | awk '{print $1}' | head --lines 1)
 
 	# Run all advanced checks
 	check_version_semantics "${NEW_VERSION}"
 	check_version_and_tag_consistency "${CURRENT_VERSION}"
 	check_version_greater
-	check_iscsc_remote "${ISCSC_REMOTE}"
+	check_iscsc_remote "${ISCSC_REMOTE_NAME}"
 
 	log_info "'${NEW_VERSION}'>'${CURRENT_VERSION}', '${NEW_VERSION}' is accepted as new version."
 
 	# Setup git branch
-	git_setup ${ISCSC_REMOTE} ${BUMP_BRANCH}
+	git_setup ${ISCSC_REMOTE_NAME} ${BUMP_BRANCH}
 
 	# Bump
 	bump_modules ${NEW_VERSION}
@@ -261,8 +261,8 @@ main () {
 
 	# Try to push bump refs
 	log_info 'Pushing branch and bump commit'
-	log_warning "pushing to \`${ISCSC_REMOTE}\` please type your passphrase/password if required:"
-	PUSH_COMMAND="git push ${ISCSC_REMOTE} ${BUMP_BRANCH} v${CURRENT_VERSION}"
+	log_warning "pushing to \`${ISCSC_REMOTE_NAME}\` please type your passphrase/password if required:"
+	PUSH_COMMAND="git push ${ISCSC_REMOTE_NAME} ${BUMP_BRANCH} v${CURRENT_VERSION}"
 	[ -z "$DRY_RUN" ] && { $PUSH_COMMAND || log_error "push failed, you can push with \`${PUSH_COMMAND}\`"; }
 
 	log_hint '`npm install` has been run during the bump, you MUST review the changes during PR review to ensure package.json and package-lock.json where compatible!!!'

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -54,11 +54,11 @@ check_arg () {
 check_dependencies () {
 	for package in ${DEPENDENCIES[@]}; do
 		if [ ! $(which $package) ]; then
-			log_error "All of '${DEPENDENCIES[@]}' are needed to bump version"
+			log_error "All of '$(echo ${DEPENDENCIES[@]})' are needed to bump version"
 			exit 1
 		fi
 	done
-	[ -n "$DRY_RUN" ] && log_ok "Dependencies: '${DEPENDENCIES[@]}' are installed on the system OK"
+	[ -n "$DRY_RUN" ] && log_ok "Dependencies: '$(echo ${DEPENDENCIES[@]})' are installed on the system OK"
 }
 
 # Check that git working directory is clean...

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -134,12 +134,12 @@ get_remote () {
 }
 
 git_setup () {
-	local iscsc_remote="$1"
+	local iscsc_remote_name="$1"
 	local bump_branch="$2"
 	# ...and checkout on main to create a version bump branch
 	# (working dir is empty check passed)
-	log_info "Checkout on ${iscsc_remote}/main"
-	[ -z "$DRY_RUN" ] && git checkout ${iscsc_remote}/main
+	log_info "Checkout on ${iscsc_remote_name}/main"
+	[ -z "$DRY_RUN" ] && git checkout ${iscsc_remote_name}/main
 	log_info "switching to ${bump_branch}"
 	[ -z "$DRY_RUN" ] && git switch -c ${bump_branch}
 }


### PR DESCRIPTION
This PR removes the old way of using `bump.sh`, e.g. `./scripts/bump.sh <version>` and add three new flags to bump either to patch, minor or major version! with `--patch/-p` `--minor/-m` or `--major/-M`. It also wraps everything into functions for a cleaner script and adds a test that checks that the most recent git tag and the current version are compatible.