### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .env.production
 .env.development
 certbot
+node_modules
+package-lock.json
+team.txt


### PR DESCRIPTION
Regarding the recents PR merged, the gitignore isn't up to date.

I added:
- node_modules and package-lock.json to ignore the npm packed installed at the root folder by the bump scripts
- the team.txt file which includes the public keys of the team for the gpg_share script