### PR TITLE
Fix CI issue: action fetches wrong repo

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           # Make sure the actual branch is checked out when running on pull requests
           ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Prettify code
         uses: creyD/prettier_action@v4.3


### PR DESCRIPTION
This PR will solve the CI issue by adding the right repo to checkout.
Currently, when opening a PR from a fork, the prettier action fails to checkout the branch because it looks for it in iscsc/iscsc.fr instead of the forked repo.

I tested the fix with my fork.