### PR TITLE
Migrate database to localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,7 @@ SERVER_NAME=yourdomainename.com  # your domain name, for the nginx configuration
 
 # mongodb setup
 DB_NAME=XXX
-DB_USER=XXX
-DB_PASSWORD=XXX
+DB_PORT=XXX
 
 # cors
 CLIENT_ORIGIN=http://localhost:$REACT_PORT  # URL of the frontend, to make a cors exception

--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ cp .env.example .env.development
 
 After copying the example config of `.env`, you must fill in the missing information in this file. Check the example for more information.
 
-> If you don't know how to deploy your database, consider using [Atlas](https://www.mongodb.com/atlas/database).
-
 #### Backend
 
 From the root directory of the repository, do the following:

--- a/backend/app.js
+++ b/backend/app.js
@@ -8,7 +8,7 @@ const articleRoutes = require('./routes/articles')
 const httpServer = createServer(app)
 require('dotenv').config({ path: `../.env.${process.env.NODE_ENV}` })
 
-const { DB_USER, DB_PASSWORD, DB_NAME, NODE_PORT, CLIENT_ORIGIN } = process.env
+const { DB_PORT, DB_NAME, NODE_PORT, CLIENT_ORIGIN } = process.env
 
 app.use(cors({ origin: CLIENT_ORIGIN || 'http://localhost:3000' }))
 app.use(express.json({ limit: '1MB' }))
@@ -19,10 +19,9 @@ app.get('/', (req, res) => {
   res.send('iscsc.fr is running')
 })
 
+uri = `mongodb://mongodb:${DB_PORT}/${DB_NAME}?retryWrites=true&w=majority`
 mongoose
-  .connect(
-    `mongodb+srv://${DB_USER}:${DB_PASSWORD}@iscsc.a11re32.mongodb.net/${DB_NAME}?retryWrites=true&w=majority`
-  )
+  .connect(uri)
   .then(() => {
     httpServer.listen(NODE_PORT || 3001, () => {
       console.log(`Server listening: http://localhost:${NODE_PORT}`)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,23 @@
 version: "3.8"
 
 services:
+  mongodb:
+    image: docker.io/bitnami/mongodb:4.4
+    networks:
+      - database
+    restart: always
+    env_file: ./.env.production
+    ports:
+      - $DB_PORT:$DB_PORT
+    volumes:
+      - './mongodb:/data/db'
+
   node-app:
+    depends_on:
+      - mongodb
+    networks:
+      - proxy
+      - database
     build: ./backend
     restart: unless-stopped
     env_file: ./.env.production
@@ -11,6 +27,8 @@ services:
   react-app:
     depends_on:
       - node-app
+    networks:
+      - proxy
     env_file: ./.env.production
     build:
       context: ./frontend
@@ -19,9 +37,12 @@ services:
 
   nginx:
     restart: always
+    networks:
+      - proxy
     depends_on:
       - react-app
       - node-app
+      - mongodb
     build:
       context: ./nginx
       args:
@@ -40,3 +61,7 @@ services:
     volumes:
       - ./certbot/www/:/var/www/certbot/:rw
       - ./certbot/conf/:/etc/letsencrypt/:rw
+
+networks:
+  proxy:
+  database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - $DB_PORT:$DB_PORT
     volumes:
-      - './mongodb:/data/db'
+      - "./mongodb:/data/db"
 
   node-app:
     depends_on:


### PR DESCRIPTION
This PR removes the *hardcoded* values of the remote atlas database.
It introduces a new local database deployment in the docker-compose workflow.
The database is secured thanks to docker networking.

I tested the whole migration :heavy_check_mark: 

:warning: This PR doesn't migrate the current atlas db to the new local one. This action must be done "by hand" when the website will be bumped.