### PR TITLE
Fix database container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ certbot
 node_modules
 package-lock.json
 team.txt
+mongodb/**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   mongodb:
-    image: docker.io/bitnami/mongodb:4.4
+    image: docker.io/bitnami/mongodb:latest
     networks:
       - database
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - database
     restart: always
     env_file: ./.env.production
+    environment:
+      - "MONGODB_EXTRA_FLAGS=--port=$DB_PORT"
     ports:
       - $DB_PORT:$DB_PORT
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - $DB_PORT:$DB_PORT
     volumes:
-      - "./mongodb:/data/db"
+      - './mongodb/prod:/bitnami/mongodb'
 
   node-app:
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - $DB_PORT:$DB_PORT
     volumes:
-      - './mongodb/prod:/bitnami/mongodb'
+      - "./mongodb/prod:/bitnami/mongodb"
 
   node-app:
     depends_on:


### PR DESCRIPTION
close #94 

We should however take care of choosing an updated version of `bitnami/mongodb` image, 4.4 is pretty old... https://hub.docker.com/r/bitnami/mongodb

:warning: **IMPORTANT** from [bitnami documentation](https://hub.docker.com/r/bitnami/mongodb)
> NOTE: As this is a non-root container, the mounted files and directories must have the proper permissions for the UID 1001.

meaning `rw` I think (but maybe `x` too didn't test it)
This is part of this [debate](https://docs.bitnami.com/tutorials/work-with-non-root-containers/) and I think we should take greater care to use unprivileged users in our images... we should open an issue about that
At the moment it only means that when deploying we must ensure that this condition above is true, but a deployment script could take care of this.